### PR TITLE
Fix consulrunner build tags for Windows

### DIFF
--- a/consulrunner/stop.go
+++ b/consulrunner/stop.go
@@ -1,4 +1,5 @@
 // +build !windows
+
 package consulrunner
 
 import (

--- a/consulrunner/stop_windows.go
+++ b/consulrunner/stop_windows.go
@@ -1,4 +1,3 @@
-// +build windows
 package consulrunner
 
 import (


### PR DESCRIPTION
Whitespace is important. Also, an underscore in the file name implies
the associated tag.

Signed-off-by: Anthony Emengo <aemengo@pivotal.io>